### PR TITLE
Add support for camel-case text selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,36 @@
             {
                 "key": "cmd+0",
                 "command": "workbench.action.toggleSidebarVisibility"
+            },
+            {
+                "key": "alt+right",
+                "command": "cursorWordPartRight",
+                "when": "textInputFocus"
+            },
+            { 
+                "key": "shift+alt+right", 
+                "command": "cursorWordPartRightSelect",
+                "when": "textInputFocus"
+            },
+            { 
+                "key": "alt+left", 
+                "command": "cursorWordPartStartLeft",
+                "when": "textInputFocus"
+            },
+            { 
+                "key": "shift+alt+left", 
+                "command": "cursorWordPartStartLeftSelect",
+                "when": "textInputFocus"
+            },
+            {
+                "key": "alt+backspace",
+                "command": "deleteWordPartLeft",
+                "when": "textInputFocus && !editorReadonly" 
+            },
+            { 
+                "key": "shift+alt+backspace", 
+                "command": "deleteWordPartRight",
+                "when": "textInputFocus && !editorReadonly" 
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -92,32 +92,32 @@
                 "command": "workbench.action.toggleSidebarVisibility"
             },
             {
-                "key": "alt+right",
+                "key": "ctrl+right",
                 "command": "cursorWordPartRight",
                 "when": "textInputFocus"
             },
             { 
-                "key": "shift+alt+right", 
+                "key": "shift+ctrl+right", 
                 "command": "cursorWordPartRightSelect",
                 "when": "textInputFocus"
             },
             { 
-                "key": "alt+left", 
+                "key": "ctrl+left", 
                 "command": "cursorWordPartStartLeft",
                 "when": "textInputFocus"
             },
             { 
-                "key": "shift+alt+left", 
+                "key": "shift+ctrl+left", 
                 "command": "cursorWordPartStartLeftSelect",
                 "when": "textInputFocus"
             },
             {
-                "key": "alt+backspace",
+                "key": "ctrl+backspace",
                 "command": "deleteWordPartLeft",
                 "when": "textInputFocus && !editorReadonly" 
             },
             { 
-                "key": "shift+alt+backspace", 
+                "key": "shift+ctrl+backspace", 
                 "command": "deleteWordPartRight",
                 "when": "textInputFocus && !editorReadonly" 
             }


### PR DESCRIPTION
This commit binds Visual Studio Code's "sub-word navigation" actions to Xcode's default keyboard shortcuts. Sub-word navigation support was added in the June 2018 release of Visual Studio Code (1.25).