### PR TITLE
Re-map fold unfold and move line up down.

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,16 @@
             {
                 "key": "alt+cmd+]",
                 "command": "editor.action.moveLinesDownAction"
+            },
+            {
+                "key": "alt+up",
+                "command": "",
+                "when": "editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "alt+down",
+                "command": "",
+                "when": "editorTextFocus && !editorReadonly"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -90,6 +90,22 @@
             {
                 "key": "cmd+0",
                 "command": "workbench.action.toggleSidebarVisibility"
+            },
+            {
+                "key": "alt+cmd+left",
+                "command": "editor.fold"
+            },
+            {
+                "key": "alt+cmd+right",
+                "command": "editor.unfold"
+            },
+            {
+                "key": "alt+cmd+[",
+                "command": "editor.action.moveLinesUpAction"
+            },
+            {
+                "key": "alt+cmd+]",
+                "command": "editor.action.moveLinesDownAction"
             }
         ]
     },


### PR DESCRIPTION
This commit maps Visual Studio Code's "fold", "unfold", "move line up", and "move line down" actions to Xcode's default keyboard shortcuts. Tested in Visual Studio Code version 1.31.0. 