### PR TITLE
Re-map the Edit All in Scope shortcut.

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
                 "key": "shift+ctrl+backspace",
                 "command": "deleteWordPartRight",
                 "when": "textInputFocus && !editorReadonly"
+            },
+            { 
+                "key": "ctrl+cmd+e",
+                "command": "editor.action.changeAll",
+                "when": "editorTextFocus && !editorReadonly"
             }
         ]
     },


### PR DESCRIPTION
Re-map the Edit All in Scope shortcut. Tested in Visual Studio Code version 1.31.1. 