### PR TITLE
Reveal breadcrumb selector 

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,11 @@
                 "key": "cmd+l",
                 "command": "workbench.action.gotoLine",
                 "when": "textInputFocus"
+            },
+            {
+                "key": "ctrl+6",
+                "command": "breadcrumbs.focusAndSelect",
+                "when": "breadcrumbsPossible"
             }
         ]
     },


### PR DESCRIPTION
Add shortcut to reveal VSCode's breadcrumb selector for symbols just like revealing Xcode's jump bar.

Breadcrumb selector

<img width="681" alt="v" src="https://user-images.githubusercontent.com/1231767/156059552-c5125475-5c37-413d-ac2a-1c3fd5d0a64b.png">

Jump bar

<img width="493" alt="x" src="https://user-images.githubusercontent.com/1231767/156059565-26785235-6b60-4772-9160-bb35e76871d0.png">

