### PR TITLE
Match addSelectionToNextFindMatch command to Xcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "contributes": {
         "keybindings": [
 			{
-				"key": "cmd+e",
+				"key": "alt+cmd+e",
 				"command": "editor.action.addSelectionToNextFindMatch"
 			},         
 			{


### PR DESCRIPTION
Currently set to cmd+e but Xcode default is opt+cmd+e

![20220526-063840 Key Bindings CleanShot@2x](https://user-images.githubusercontent.com/2302078/170472579-9072bff6-5596-4cf0-9513-9fb88986caa2.png)

