### PR TITLE
Adding line selection forward & backward (shift+alt+up/down)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,16 @@
                 "command": "workbench.action.navigateForward"
             },
             {
+                "key": "shift+alt+up",
+                "command": "cursorLineStartSelect",
+                "when": "textInputFocus"
+            },
+            {
+                "key": "shift+alt+down",
+                "command": "cursorLineEndSelect",
+                "when": "textInputFocus"
+            },
+            {
                 "key": "cmd+1",
                 "command": "workbench.view.explorer"
             },


### PR DESCRIPTION
As per Xcode default behavior, this selects up until the end (or start) of the current line (starting at cursor position).

https://user-images.githubusercontent.com/1275218/198831290-d5b01838-8d7a-40f6-9949-67e6e442a0ae.mov

