### PR TITLE
Ctrl+cmd+y for debug continue/pause

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,16 @@
                 "when": "inDebugMode"
             },
             {
+                "key": "ctrl+cmd+y",
+                "command": "workbench.action.debug.continue",
+                "when": "inDebugMode && debugState == stopped"
+            },
+            {
+                "key": "ctrl+cmd+y",
+                "command": "workbench.action.debug.pause",
+                "when": "inDebugMode && debugState == running"
+            },
+            {
                 "key": "cmd+b",
                 "command": "workbench.action.tasks.build"
             },


### PR DESCRIPTION
A quick way to pause/continue execution in the Debugger without needing Function keys.  

Original shortcut defined [here](https://developer.apple.com/library/archive/documentation/IDEs/Conceptual/xcode_help-command_shortcuts/MenuCommands/MenuCommands014.html)
![image](https://user-images.githubusercontent.com/3021159/199805122-9289c882-92f4-40a0-9373-f020aa33a8be.png)
