### PR TITLE
Add Ctrl-i for Xcode's Re-Indent

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,11 @@
                 "when": "editorTextFocus && !editorReadonly"
             },
             {
+                "key": "ctrl+i",
+                "command": "editor.action.formatSelection",
+                "when": "editorHasDocumentSelectionFormattingProvider && editorTextFocus && !editorReadonly"
+            },
+            {
                 "key": "enter",
                 "command": "acceptSelectedSuggestion",
                 "when": "editorTextFocus && suggestWidgetVisible"


### PR DESCRIPTION
Mapped to editor.action.formatSelection, which is pretty much the same thing.