### PR TITLE
Add ctrl+6 as jump bar file symbol search

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,18 +31,18 @@
     "icon": "xcode-keyboard.png",
     "contributes": {
         "keybindings": [
-			{
-				"key": "cmd+e",
-				"command": "editor.action.addSelectionToNextFindMatch"
-			},         
-			{
-				"key": "cmd+shift+j",
-				"command": "workbench.files.action.showActiveFileInExplorer"
-			},            
-			{
-				"key": "cmd+ctrl+up",
-				"command": "C_Cpp.SwitchHeaderSource"
-			},            
+            {
+                "key": "cmd+e",
+                "command": "editor.action.addSelectionToNextFindMatch"
+            },
+            {
+                "key": "cmd+shift+j",
+                "command": "workbench.files.action.showActiveFileInExplorer"
+            },
+            {
+                "key": "cmd+ctrl+up",
+                "command": "C_Cpp.SwitchHeaderSource"
+            },
             {
                 "key": "shift+cmd+]",
                 "command": "workbench.action.nextEditor"
@@ -199,6 +199,10 @@
                 "key": "cmd+d",
                 "command": "editor.action.duplicateSelection",
                 "when": "editorTextFocus"
+            },
+            {
+                "key": "ctrl+6",
+                "command": "workbench.action.gotoSymbol"
             }
         ]
     },


### PR DESCRIPTION
This adds ctrl+6 as a shortcut, similar to XCodes jump-bar menu search for symbols:
https://dasdom.dev/jumpbar-in-xcode/
<img width="785" alt="image" src="https://github.com/stevemoser/vscode-xcode-keybindings/assets/104132113/375f1d77-3cb3-4e58-ab3d-c73f7f861736">
